### PR TITLE
Correct/projects illustration build bug

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,3 +1,17 @@
+import chip8ppImg from '../assets/slippery_slope.png';
+import scanscraperImg from '../assets/scan-scraper.png';
+import pokemonppImg from '../assets/pokemonpp.png';
+import gotalkImg from '../assets/gotalk.svg';
+import portfolioImg from '../assets/pt.jpg';
+
+const illustrations = {
+  chip8: chip8ppImg,
+  scan: scanscraperImg,
+  pokemonpp: pokemonppImg,
+  gotalk: gotalkImg,
+  pt: portfolioImg
+}
+
 function ProjectCard({ title, description, techs, illustration, link }) {
   return (
     <div
@@ -11,7 +25,7 @@ function ProjectCard({ title, description, techs, illustration, link }) {
         className="block"
       >
         <img
-          src={`src/assets/${illustration}`}
+          src={illustrations[illustration]}
           alt={title}
           className="w-full h-52 object-cover rounded-lg border border-white/10 transition-transform duration-300 ease-in-out hover:scale-102"
         />

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,35 +1,35 @@
 [
   {
     "title": "CHIP-8pp",
-    "illustration": "slippery_slope.png",
+    "illustration": "chip8",
     "description": "A fully-tested CHIP-8 emulator written in modern C++. Faithful to the original specification, with clean architecture and deterministic behavior.",
     "techs": ["C++", "CMake", "Bash", "Docker"],
     "link": "https://github.com/EliasLd/CHIP-8pp"
   },
   {
     "title": "Scan Scraper",
-    "illustration": "scan-scraper.png",
+    "illustration": "scan",
     "description": "A CLI and TUI tool to scrape manga chapters from anime-sama.fr and convert them to PDF. Built in Go with Bubble Tea and custom PDF/image processing.",
     "techs": ["Go", "Bubble Tea", "CLI", "TUI", "Web Scraping"],
     "link": "https://github.com/EliasLd/scan-scraper"
   },
   {
     "title": "pokemonpp",
-    "illustration": "pokemonpp.png",
+    "illustration": "pokemonpp",
     "description": "A retro-inspired Pokémon game in the terminal, built in C++ with a full ANSI rendering system. Includes custom decoding and encoding of Pokémon sprites into ANSI art for smooth display in TUI.",
     "techs": ["C++", "TUI"],
     "link": "https://github.com/EliasLd/pokemonpp"
   },
   {
     "title": "gotalk-backend - WIP",
-    "illustration": "gotalk.svg",
+    "illustration": "gotalk",
     "description": "Modular and scalable Go backend for a chat app. Includes JWT-based authentication, user registration, public/private rooms, and real-time messaging pipeline (in progress).",
     "techs": ["Go", "JWT"],
     "link": "https://github.com/EliasLd/gotalk-backend"
   },
   {
     "title": "Portfolio Website",
-    "illustration": "pt.jpg",
+    "illustration": "pt",
     "description": "Personal portfolio built with React and TailwindCSS. Features animated components with Framer Motion and a clean modular structure.",
     "techs": ["Javascript", "React", "TailwindCSS"],
     "link": "https://github.com/EliasLd/portfolio"

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,6 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
### Pull Request: Fix project illustrations not loading in production build

#### Summary

This PR fixes an issue where the project illustrations were not loading properly in the production build.

#### Changes

- Renamed and standardized illustration keys in `projects.json` and imports
- Updated `ProjectCard` to use imported assets via an `illustrations` mapping object instead of relying on relative paths
- Modified `vite.config.js` to set `base: './'` in order to ensure proper asset resolution when the site is served from a subdirectory or file system

#### Context

In local development, images were loading as expected, but failed to load after deployment due to incorrect asset paths. This fix ensures compatibility with the Vite build output and static file serving using Caddy.

#### Test

- [x] Verified image loading locally with `npx serve dist`
- [x] Verified image loading on deployed site after build and redeploy

Let me know if anything needs to be adjusted.
